### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,15 @@
 Redisdb
 #######
 
-.. image:: https://pypip.in/wheel/django-redisdb/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/django-redisdb.svg
     :target: https://pypi.python.org/pypi/django-redisdb/
     :alt: Wheel Status
 
-.. image:: https://pypip.in/version/django-redisdb/badge.svg
+.. image:: https://img.shields.io/pypi/v/django-redisdb.svg
     :target: https://pypi.python.org/pypi/django-redisdb/
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/django-redisdb/badge.svg
+.. image:: https://img.shields.io/pypi/l/django-redisdb.svg
     :target: https://pypi.python.org/pypi/django-redisdb/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-redisdb))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-redisdb`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.